### PR TITLE
[update]管理者ページにて投稿を削除すると存在しないパスへ遷移しエラーとなっていたためUserの削除と同じように一覧ページへ遷移する…

### DIFF
--- a/app/controllers/admin/posts_controller.rb
+++ b/app/controllers/admin/posts_controller.rb
@@ -10,6 +10,6 @@ class Admin::PostsController < ApplicationController
   def destroy
     @post = Post.find(params[:id])
     @post.destroy
-    redirect_to admin_posts_path
+    redirect_to admin_management_index_path
   end
 end


### PR DESCRIPTION
…ように修正