### PR TITLE
134 postedit notplaceeditanddelete

### DIFF
--- a/app/controllers/public/places_controller.rb
+++ b/app/controllers/public/places_controller.rb
@@ -28,18 +28,21 @@ class Public::PlacesController < ApplicationController
   end
 
   def update
-     places_data = place_params # place_params を呼び出してデータ取得
+    places_data = place_params # place_params を呼び出してデータ取得
 
     ActiveRecord::Base.transaction do
+
+      Place.where(post_id: params[:post_id]).destroy_all
+
       places_data.each do |place_data|
-        place = Place.find_or_initialize_by(place_num: place_data[:place_num], post_id: params[:post_id])
+        place = Place.new(place_data.except(:image).merge(post_id: params[:post_id]))
 
         # 画像データを適切にアタッチ
         if place_data[:image].is_a?(ActionDispatch::Http::UploadedFile)
           place.image.attach(place_data[:image])
         end
 
-        unless place.update(place_data.except(:image)) # :image を除外して更新
+        unless place.save
           render json: { error: '投稿に失敗しました', details: place.errors.full_messages }, status: :unprocessable_entity and return
         end
       end

--- a/app/javascript/controllers/place_controller.js
+++ b/app/javascript/controllers/place_controller.js
@@ -552,8 +552,11 @@ export default class extends Controller {
       placeTabs = document.querySelectorAll('.placedata')
       placeTabs.forEach((tab, index) =>{
         console.log("index:", index)
-
-        tab.textContent = this.tabdatas[index].place_num + ":" + this.tabdatas[index].place_name
+        if(this.tabdatas[index]){
+          tab.textContent = this.tabdatas[index].place_num + ":" + this.tabdatas[index].place_name
+        }else{
+          tab.textContent = index + 1
+        }
       })
 
       if(this.currentindex == this.tabdatas.length){

--- a/app/javascript/controllers/place_controller.js
+++ b/app/javascript/controllers/place_controller.js
@@ -505,6 +505,7 @@ export default class extends Controller {
     this.addMarker(this.tabdatas[0].latitude,this.tabdatas[0].longitude,this.tabdatas[0].place_name)
     this.showFormData(this.tabdatas[0].comment, this.tabdatas[0].good, this.tabdatas[0].image, this.tabdatas[0].place_name)
     this.visibleDeleteBtn(true)
+    this.changesaveTabButtonText(true)
   }
 
   addTabsHTML(index){


### PR DESCRIPTION
# 修正内容
- 観光地編集後DBにコミットする際は、DBにすでに登録されている観光地を一度削除してからDBに更新を行う
- 既存のタブと新規のタブがあった場合、既存のタブを削除後新規のタブのタブ番号が異なっていたため修正